### PR TITLE
Fix: Resolve nil pointer dereference during GraphQL schema initializa…

### DIFF
--- a/graphqlhandler/schema.go
+++ b/graphqlhandler/schema.go
@@ -60,7 +60,7 @@ func init() {
 				Resolve: healthCheckResolver,
 			},
 			"getLoanApplication": &graphql.Field{
-				Type: loanApplicationType, // Nullable as per schema
+				Type: GetLoanApplicationType(), // Nullable as per schema
 				Args: graphql.FieldConfigArgument{
 					"uuid": &graphql.ArgumentConfig{
 						Type: graphql.NewNonNull(graphql.ID),

--- a/graphqlhandler/types.go
+++ b/graphqlhandler/types.go
@@ -143,9 +143,20 @@ func GetLoanApplicationType() *graphql.Object {
 	// However, with all types in this file, direct use of loanApplicationType should be fine after init() runs.
 	// For safety and to ensure it's initialized, especially if types were split into more files:
 	if loanApplicationType == nil {
-		// This case should ideally not happen if init() functions are correctly managed by Go runtime.
-		// Re-run init logic or panic if critical. For now, let's assume init() handles it.
-		// The init() function for loanApplicationType should handle its setup.
+		// Explicitly initialize if it hasn't been already.
+		// This mirrors the logic in the init() function.
+		loanApplicationType = graphql.NewObject(graphql.ObjectConfig{
+			Name: "LoanApplication",
+			Fields: graphql.Fields{
+				"uuid":          &graphql.Field{Type: graphql.NewNonNull(graphql.ID)},
+				"status":        &graphql.Field{Type: graphql.NewNonNull(graphql.String)},
+				"proposed_loan": &graphql.Field{Type: graphql.NewNonNull(proposedLoanType)},
+				"collateral":    &graphql.Field{Type: graphql.NewNonNull(collateralType)},
+				"customer":      &graphql.Field{Type: graphql.NewNonNull(customerType)},
+				"created_at":    &graphql.Field{Type: graphql.NewNonNull(graphql.String)}, 
+				"updated_at":    &graphql.Field{Type: graphql.NewNonNull(graphql.String)}, 
+			},
+		})
 	}
 	return loanApplicationType
 }


### PR DESCRIPTION
…tion

The application was panicking due to `loanApplicationType` being nil when `graphql.NewSchema` was called. This was caused by the initialization order of `init()` functions in the `graphqlhandler` package.

This fix addresses the issue by:
1. Modifying `graphqlhandler/schema.go` to call `GetLoanApplicationType()` when referencing `loanApplicationType` in the root query definition.
2. Ensuring that `GetLoanApplicationType()` in `graphqlhandler/types.go` correctly initializes and returns the `loanApplicationType` if it hasn't been initialized yet. This change was key to resolving the panic.

The application now starts successfully without the panic.